### PR TITLE
feat/add pricing page, connect with payment form

### DIFF
--- a/client/dist/css/style.css
+++ b/client/dist/css/style.css
@@ -22,7 +22,6 @@
 }
 .profileheader {
   text-align: center;
-
 }
 
 h1.explanation {
@@ -107,4 +106,21 @@ form {
 
 #addLineItemButton, .trashButton {
   padding-left: 11px;
+}
+
+.eight.wide.column.subscriptions {
+  text-align: center;
+  border: 0.5px solid #f2f2f2;
+}
+
+#subscriptionsHeader {
+  text-align: center;
+}
+
+.subscriptionButtons {
+  font-size: 20px !important;
+}
+
+#subscriptionTitle {
+  font-size: 40px !important;
 }

--- a/client/dist/css/style.css
+++ b/client/dist/css/style.css
@@ -72,10 +72,7 @@ form {
 }
 
 #getStartedButton {
-  width: 150px !important;
-  height: 50px !important;
-  background-color: #0fd392 !important;
-  font-size: 15px !important;
+  font-size: 17px !important;
 }
 
 .dashboardviews {
@@ -115,6 +112,7 @@ form {
 
 #subscriptionsHeader {
   text-align: center;
+  margin-bottom: 50px;
 }
 
 .subscriptionButtons {

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -6,6 +6,7 @@ import TutorsView from './TutorsView.jsx';
 import InvoiceListView from './InvoiceListView.jsx';
 import InvoiceCreateView from './InvoiceCreateView.jsx';
 import SubscriptionsView from './SubscriptionsView.jsx';
+import SubscriptionsPaymentView from './SubscriptionsPaymentView.jsx';
 import { Link, Route, Switch } from 'react-router-dom';
 import { Menu } from 'semantic-ui-react';
 import axios from 'axios';
@@ -144,6 +145,8 @@ class App extends React.Component {
           <Route path='/dashboard/:tutor' render={() => <DashboardView tutor={this.state.user.username} />} />
           <Route path='/createInvoice' render={() => <InvoiceCreateView /> } />
           <Route path='/invoiceList' render={() => <InvoiceListView /> } />
+          <Route path='/pricing' render={() => <SubscriptionsView /> } />
+          <Route path='/subscribe' render={() => <SubscriptionsPaymentView /> } />
         </Switch>
       </div>
     );

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -5,6 +5,7 @@ import HomeView from './HomeView.jsx';
 import TutorsView from './TutorsView.jsx';
 import InvoiceListView from './InvoiceListView.jsx';
 import InvoiceCreateView from './InvoiceCreateView.jsx';
+import SubscriptionsView from './SubscriptionsView.jsx';
 import { Link, Route, Switch } from 'react-router-dom';
 import { Menu } from 'semantic-ui-react';
 import axios from 'axios';

--- a/client/src/components/DashboardView.jsx
+++ b/client/src/components/DashboardView.jsx
@@ -8,7 +8,8 @@ import AvailabilityView from './AvailabilityView.jsx';
 import ProfileView from './ProfileView.jsx';
 import StudentsView from './StudentsView.jsx';
 import InvoiceListView from './InvoiceListView.jsx';
-import InvoiceCreateView from './InvoiceCreateView.jsx'
+import InvoiceCreateView from './InvoiceCreateView.jsx';
+import SubscriptionsView from './SubscriptionsView.jsx';
 import HomeView from './HomeView.jsx';
 import axios from 'axios';
 import _ from 'lodash';
@@ -186,6 +187,7 @@ class DashboardView extends React.Component {
 
   setView(e) {
     this.setState({view: e});
+    this.toggleVisibility();
   }
 
   render () {
@@ -256,6 +258,12 @@ class DashboardView extends React.Component {
           <InvoiceListView />
         </div>
       )
+    } else if (this.state.view === 'subscriptions') {
+      currentView = (
+        <div className="dashboardviews">
+          <SubscriptionsView />
+        </div>
+      )
     } else {
       currentView = (
         <div className="dashboardviews">
@@ -314,8 +322,12 @@ class DashboardView extends React.Component {
               Students
             </Menu.Item>
             <Menu.Item name='invoices' href="/#/dashboard" onClick={this.setView.bind(name, 'invoices')}>
-              <Icon name='money' />
-              My Invoices
+              <Icon name='file text outline' />
+              Invoices
+            </Menu.Item>
+            <Menu.Item name='subscriptions' href="/#/dashboard" onClick={this.setView.bind(name, 'subscriptions')}>
+              <Icon name='credit card' />
+              Subscription
             </Menu.Item>
           </Sidebar>
           <Sidebar.Pusher>

--- a/client/src/components/DashboardView.jsx
+++ b/client/src/components/DashboardView.jsx
@@ -327,7 +327,7 @@ class DashboardView extends React.Component {
             </Menu.Item>
             <Menu.Item name='subscriptions' href="/#/dashboard" onClick={this.setView.bind(name, 'subscriptions')}>
               <Icon name='credit card' />
-              Subscription
+              Subscriptions
             </Menu.Item>
           </Sidebar>
           <Sidebar.Pusher>

--- a/client/src/components/HomeView.jsx
+++ b/client/src/components/HomeView.jsx
@@ -29,7 +29,12 @@ class HomeView extends React.Component {
           <h1 className="ui inverted header">
           Tutor HQ
           </h1>
-          <Button id="getStartedButton" primary>Get Started</Button>
+          <Button
+            id='getStartedButton'
+            color='teal'
+            as={ Link }
+            to='/pricing'
+            primary>Get Started</Button>
         </div>
         <h1 className="explanation">How It Works</h1>
         <br/>

--- a/client/src/components/InvoiceCreateView.jsx
+++ b/client/src/components/InvoiceCreateView.jsx
@@ -265,8 +265,19 @@ class InvoiceCreateView extends React.Component {
 
         {/* Form Submit / Cancel Field */}
         <div id='invoiceButtons'>
-          <Button color='red'>Cancel</Button>
-          <Button color='green' onClick={ this.saveInvoice } as={Link} to='/invoiceList'>Save</Button>
+          <Button
+            color='red'
+            as={ Link }
+            to='/invoiceList'>
+            Cancel
+          </Button>
+          <Button
+            color='green'
+            onClick={ this.saveInvoice }
+            as={ Link }
+            to='/invoiceList'>
+            Save
+          </Button>
         </div>
       </Container>
     )

--- a/client/src/components/SubscriptionsPaymentView.jsx
+++ b/client/src/components/SubscriptionsPaymentView.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Container } from 'semantic-ui-react';
+import { Link } from 'react-router-dom';
+import { Button, Container } from 'semantic-ui-react';
 import 'semantic-ui-css/semantic.min.css';
 
 class SubscriptionsPaymentView extends React.Component {
@@ -934,9 +935,16 @@ class SubscriptionsPaymentView extends React.Component {
                 </div>
               </div>
             </div>
-            <div className="positive ui button" tabIndex="0">
+            <Button
+              color='green'>
               Submit
-            </div>
+            </Button>
+            <Button
+              color='red'
+              as={Link}
+              to='/pricing'>
+              Cancel
+            </Button>
           </form>
         </Container>
       </div>

--- a/client/src/components/SubscriptionsView.jsx
+++ b/client/src/components/SubscriptionsView.jsx
@@ -1,36 +1,50 @@
-var InputField = React.createClass({
-  render: function() {
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Button, Container, List } from 'semantic-ui-react';
+
+class SubscriptionsView extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
     return (
-      <div className="field">
-        <label>{this.props.label}</label>
-        <input type="text" placeholder={this.props.placeholder} />
-      </div>
+      <Container>
+        <div id='subscriptionsHeader'>
+          <h1 id='subscriptionTitle'>Pricing</h1>
+          <h3>TutorHQ is free to use.<br/>Upgrade your classroom to bolster it with even better features.</h3>
+        </div>
+        <div className='ui grid'>
+          <div className='eight wide column subscriptions'>
+            <h1>TutorHQ</h1>
+            <h3>Free</h3>
+            <List as='ul'>
+              <List.Item as='li'>Scheduling Tool</List.Item>
+              <List.Item as='li'>Video Chat</List.Item>
+            </List>
+            <Button
+              className='subscriptionButtons'
+              color='grey'>
+              Get Started For Free
+            </Button>
+          </div>
+          <div className='eight wide column subscriptions'>
+            <h1>TutorHQ Premium</h1>
+            <h3>Only $4.99/mo</h3>
+            <List as='ul'>
+              <List.Item as='li'>Whiteboard</List.Item>
+              <List.Item as='li'>Text Editor</List.Item>
+            </List>
+            <Button
+              className='subscriptionButtons'
+              color='teal'>
+              Upgrade to TutorHQ Premium
+            </Button>
+          </div>
+        </div>
+      </Container>
     )
   }
-});
+}
 
-var PaymentForm = React.createClass({
-  render: function() {
-    return (
-      <form>
-        <ul className="card-list">
-          <li className="card visa"></li>
-          <li className="card mastercard"></li>
-          <li className="card amex"></li>
-        </ul>
-        <InputField label="Name on Card" />
-        <InputField label="Card number" />
-        <InputField label="Expiry Date" placeholder="MM / YY" />
-        <InputField label="Security code" />
-        <button>Pay $400.00</button>
-      </form>
-    )
-  }
-})
-
-ReactDOM.render(
-  <PaymentForm />,
-  document.getElementById('page')
-);
-
-// https://codepen.io/pandaduc/pen/zGawdY
+export default SubscriptionsView;

--- a/client/src/components/SubscriptionsView.jsx
+++ b/client/src/components/SubscriptionsView.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { Link } from 'react-router-dom';
 import { Button, Container, List } from 'semantic-ui-react';
 
 class SubscriptionsView extends React.Component {
@@ -23,6 +24,7 @@ class SubscriptionsView extends React.Component {
               <List.Item as='li'>Video Chat</List.Item>
             </List>
             <Button
+              href='/auth/google'
               className='subscriptionButtons'
               color='grey'>
               Get Started For Free
@@ -35,7 +37,10 @@ class SubscriptionsView extends React.Component {
               <List.Item as='li'>Whiteboard</List.Item>
               <List.Item as='li'>Text Editor</List.Item>
             </List>
+            <h3>Start your 30 day free trial!</h3>
             <Button
+              as={ Link }
+              to='/subscribe'
               className='subscriptionButtons'
               color='teal'>
               Upgrade to TutorHQ Premium


### PR DESCRIPTION
Updates:
- Added pricing page with two options, free vs. premium
- If user clicks Free plan, direct to Google Auth. If user clicks Premium, direct to payment form (SubscriptionsPaymentView)
- **Get Started** button on home page directs user to pricing page
- Dashboard auto-hides after user clicks a specific page

Todo:
- Add Stripe Tester account + Button to SubscriptionsPaymentView to carry out a sample transaction
- If user is logged in, the Free plan button on the pricing page still redirects them to Google Auth, which makes them log in again. This should just redirect them to the Dashboard, or be hidden